### PR TITLE
to_javascript helper method for controllers

### DIFF
--- a/lib/rails_script.rb
+++ b/lib/rails_script.rb
@@ -1,5 +1,6 @@
 require 'rails_script/version'
 require 'rails_script/loader_helper'
+require 'rails_script/to_javascript'
 require 'rails_script/railtie' if defined?(Rails)
 
 module RailsScript

--- a/lib/rails_script/railtie.rb
+++ b/lib/rails_script/railtie.rb
@@ -7,5 +7,10 @@ module RailsScript
     initializer 'rails_Script.loader_helper' do
       ActionView::Base.send :include, LoaderHelper
     end
+
+    initializer 'rails_script.to_javascript' do
+      ActionController::Base.send :include, ToJavascript
+    end
+    
   end
 end

--- a/lib/rails_script/to_javascript.rb
+++ b/lib/rails_script/to_javascript.rb
@@ -1,0 +1,16 @@
+module RailsScript
+  module ToJavascript
+    extend ActiveSupport::Concern
+
+    included do
+      before_action do
+        @to_javascript = {}
+      end
+    end
+
+    def to_javascript(variables = {})
+      @to_javascript.merge!(variables)
+    end
+
+  end
+end


### PR DESCRIPTION
I love what this Gem is doing. I was just integrating it into a project where I identified a need to add some variables in the application controller, and some others in the page controller.

Instead of checking that `@to_javascript` was set and then merging the hashes I wrote a small concern to take care of it for me.

You can now call the `to_javascript` method multiple times from your controller to append your new data to the to_javascript array. For example:

``` ruby
class ApplicationController < ActionController::Base
  before_action do
    to_javascript username: @current_user.username, account: @current_account.name
  end
  ...
end
```

``` ruby
class ProjectsController < ApplicationController
  before_action do
    to_javascript project_name: @project.name
  end
end
```
